### PR TITLE
Make ZeroKit open instead of public

### DIFF
--- a/ZeroKit/ZeroKit.swift
+++ b/ZeroKit/ZeroKit.swift
@@ -5,7 +5,7 @@ import WebKit
  
  - note: The ZeroKit API is not thread safe, call only from the main thread.
  */
-public class ZeroKit: NSObject {
+open class ZeroKit: NSObject {
     
     fileprivate let config: ZeroKitConfig
     fileprivate var internalApi: InternalApi!


### PR DESCRIPTION
Swift 3 introduced some more fine grained access levels. In order to Unit test the successful integration of ZeroKit I need to create a mock class by subclassing `ZeroKit` and overwrite some of its methods. This does not work in the current setup: `cannot inherit from non-open class ZeroKit outside of its defining module`